### PR TITLE
Increase blocks shown in UI from 100 up to 500

### DIFF
--- a/html/ui/js/nrs.blocks.js
+++ b/html/ui/js/nrs.blocks.js
@@ -243,7 +243,7 @@ var NRS = (function(NRS, $, undefined) {
 
 					var blockIds = response.blockIds.slice(0, 100);
 
-					if (response.blockIds.length > 100) {
+					if (response.blockIds.length > 500) {
 						$("#blocks_page_forged_warning").show();
 					}
 
@@ -350,7 +350,7 @@ var NRS = (function(NRS, $, undefined) {
 		$("#blocks_average_amount").html(NRS.formatStyledAmount(averageAmount)).removeClass("loading_dots");
 
 		if (NRS.blocksPageType == "forged_blocks") {
-			if (blocks.length == 100) {
+			if (blocks.length == 500) {
 				var blockCount = blocks.length + "+";
 			} else {
 				var blockCount = blocks.length;


### PR DESCRIPTION
Simple UI change to increase the number of mined blocks shown from 100 to 500. Useful for users that have solo-mined more than 100 blocks, and want to see more than just the last 100 block statistics shown.
